### PR TITLE
add dependecies

### DIFF
--- a/IaC/bicep/rg-hub/hub-default.bicep
+++ b/IaC/bicep/rg-hub/hub-default.bicep
@@ -625,6 +625,7 @@ module fwPoliciesBase '../CARML/Microsoft.Network/firewallPolicies/deploy.bicep'
   scope: resourceGroup(resourceGroupName)
   dependsOn: [
     rg
+    ipgNodepoolSubnet
   ]
 }
 
@@ -702,6 +703,8 @@ module hubFw '../CARML/Microsoft.Network/azureFirewalls/deploy.bicep' = {
   }
   dependsOn: [
     rg
+    fwPoliciesBase
+    fwPolicies
     ipgNodepoolSubnet
   ]
 }


### PR DESCRIPTION
Deployment of hub failed if executed a second time. Reason was a race condition on the firewall. Now the dependency tree is updated, to prevent that from happening.