### PR TITLE
Adds additional debugging to Run Cmd Invoke Workflow

### DIFF
--- a/.github/workflows/App-AzureVote-HelmRunCmd.yml
+++ b/.github/workflows/App-AzureVote-HelmRunCmd.yml
@@ -100,6 +100,13 @@ jobs:
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
+      - name: Check Run Command is functioning
+        if: inputs.DEBUG == "true"
+        run: |
+          command="kubectl get pods"
+          echo "Sending command $command to AKS"
+          az aks command invoke -g $RG -n $AKSNAME -o json --command "${command}"
+
       - name: Check for and uninstall the Vote app
         if: inputs.FORCEHELMCLEANINSTALL == true
         run: |

--- a/.github/workflows/App-AzureVote-HelmRunCmd.yml
+++ b/.github/workflows/App-AzureVote-HelmRunCmd.yml
@@ -50,7 +50,7 @@ on:
         required: false
       HELMPACKAGEURI:
         description: "The location of the Application Helm package"
-        default: "https://github.com/Azure/aks-baseline-automation/raw/main/workloads/azure-vote/AzureVote-0.9.5.tgz"
+        default: "https://github.com/Gordonby/minihelm/raw/gb-vote-memory/samples/AzureVote-0.9.6.tgz"
         required: false
         type: string
       CURLRETRIES:

--- a/.github/workflows/App-AzureVote-HelmRunCmd.yml
+++ b/.github/workflows/App-AzureVote-HelmRunCmd.yml
@@ -101,7 +101,7 @@ jobs:
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: Check Run Command is functioning
-        if: inputs.DEBUG == "true"
+        if: inputs.DEBUG == true
         run: |
           command="kubectl get pods"
           echo "Sending command $command to AKS"

--- a/.github/workflows/App-AzureVote-HelmRunCmd.yml
+++ b/.github/workflows/App-AzureVote-HelmRunCmd.yml
@@ -50,7 +50,7 @@ on:
         required: false
       HELMPACKAGEURI:
         description: "The location of the Application Helm package"
-        default: "https://github.com/Gordonby/minihelm/raw/gb-vote-memory/samples/AzureVote-0.9.6.tgz"
+        default: "https://github.com/Azure/aks-baseline-automation/raw/main/workloads/azure-vote/AzureVote-0.9.5.tgz"
         required: false
         type: string
       CURLRETRIES:

--- a/.github/workflows/App-Test.yml
+++ b/.github/workflows/App-Test.yml
@@ -73,7 +73,7 @@ jobs:
       APPNAME: azure-vote-public
       INGRESSTYPE: PublicLoadBalancer
       #HELMPACKAGEURI will change to this repo once this repo's visibility is PUBLIC!
-      HELMPACKAGEURI: https://github.com/Gordonby/minihelm/raw/main/samples/AzureVote-0.9.5.tgz
+      HELMPACKAGEURI: https://github.com/Gordonby/minihelm/raw/main/samples/AzureVote-0.9.6.tgz
     secrets:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}

--- a/.github/workflows/App-Test.yml
+++ b/.github/workflows/App-Test.yml
@@ -72,6 +72,7 @@ jobs:
       AKSNAME: ${{ needs.ReusableWF.outputs.AKSNAME }}
       APPNAME: azure-vote-public
       INGRESSTYPE: PublicLoadBalancer
+      DEBUG: true
       #HELMPACKAGEURI will change to this repo once this repo's visibility is PUBLIC!
       HELMPACKAGEURI: https://github.com/Gordonby/minihelm/raw/main/samples/AzureVote-0.9.6.tgz
     secrets:


### PR DESCRIPTION
The azure-vote run cmd workflow is returning an error when being run against the repo's CARML secure baseline cluster.

> ERROR: (KubernetesOperationError) Failed to run command in managed cluster due to kubernetes failure. details: admission webhook "validation.gatekeeper.sh" denied the request: [azurepolicy-container-limits-2007c596c60696e5e4a5] container <user-command> memory limit <1Gi> is higher than the maximum allowed of <512Mi>
[azurepolicy-container-limits-2007c596c60696e5e4a5] container <init-command> memory limit <1Gi> is higher than the maximum allowed of <512Mi>
Code: KubernetesOperationError
Message: Failed to run command in managed cluster due to kubernetes failure. details: admission webhook "validation.gatekeeper.sh" denied the request: [azurepolicy-container-limits-2007c596c60696e5e4a5] container <user-command> memory limit <1Gi> is higher than the maximum allowed of <512Mi>
[azurepolicy-container-limits-2007c596c60696e5e4a5] container <init-command> memory limit <1Gi> is higher than the maximum allowed of <512Mi>

To isolate the error, i've added a new debug step to the workflow which simply runs the `kubectl get pods` command conditionally.

This debug step will be useful for others who are experiencing similar problems.
