### PR TITLE
Update cluster.parameters.json with updated AKS version

### DIFF
--- a/IaC/bicep/rg-spoke/cluster.parameters.json
+++ b/IaC/bicep/rg-spoke/cluster.parameters.json
@@ -16,7 +16,7 @@
             "value": "contoso.com"
         } ,
         "kubernetesVersion":{
-            "value": "1.22.4"
+            "value": "1.22.11"
         }  
         ,
         "gitOpsBootstrappingRepoHttpsUrl":{


### PR DESCRIPTION
Update AKS version from 1.22.4 (no longer available in most locations) to AKS 1.22.11 (which is available in most locations)