### PR TITLE
Updating the ResourceGroup module to latest version in CARML

### DIFF
--- a/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep
+++ b/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep
@@ -226,7 +226,7 @@ var builtInRoleNames = {
 }
 
 resource roleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = [for principalId in principalIds: {
-  name: guid(last(split(resourceId, '/')), principalId, roleDefinitionIdOrName)
+  name: guid(resourceId, principalId, roleDefinitionIdOrName)
   properties: {
     description: description
     roleDefinitionId: contains(builtInRoleNames, roleDefinitionIdOrName) ? builtInRoleNames[roleDefinitionIdOrName] : roleDefinitionIdOrName

--- a/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/.test/common/deploy.test.bicep
+++ b/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/.test/common/deploy.test.bicep
@@ -3,7 +3,8 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
-@description('Optional. The name of the resource group to deploy for a testing purposes.')
+
+@description('Optional. The name of the resource group to deploy for testing purposes.')
 @maxLength(90)
 param resourceGroupName string = 'ms.resources.resourcegroups-${serviceShort}-rg'
 
@@ -16,9 +17,9 @@ param serviceShort string = 'rrgcom'
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
-// =========== //
-// Deployments //
-// =========== //
+// ============ //
+// Dependencies //
+// ============ //
 
 // General resources
 // =================
@@ -27,9 +28,9 @@ resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   location: location
 }
 
-module resourceGroupResources 'dependencies.bicep' = {
+module nestedDependencies 'dependencies.bicep' = {
   scope: resourceGroup
-  name: '${uniqueString(deployment().name, location)}-paramNested'
+  name: '${uniqueString(deployment().name, location)}-nestedDependencies'
   params: {
     managedIdentityName: 'dep-<<namePrefix>>-msi-${serviceShort}'
   }
@@ -40,7 +41,7 @@ module resourceGroupResources 'dependencies.bicep' = {
 // ============== //
 
 module testDeployment '../../deploy.bicep' = {
-  name: '${uniqueString(deployment().name)}-test-${serviceShort}'
+  name: '${uniqueString(deployment().name, location)}-test-${serviceShort}'
   params: {
     enableDefaultTelemetry: enableDefaultTelemetry
     name: '<<namePrefix>>${serviceShort}001'
@@ -49,7 +50,7 @@ module testDeployment '../../deploy.bicep' = {
       {
         roleDefinitionIdOrName: 'Reader'
         principalIds: [
-          resourceGroupResources.outputs.managedIdentityPrincipalId
+          nestedDependencies.outputs.managedIdentityPrincipalId
         ]
         principalType: 'ServicePrincipal'
       }

--- a/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/.test/min/deploy.test.bicep
+++ b/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/.test/min/deploy.test.bicep
@@ -3,6 +3,7 @@ targetScope = 'subscription'
 // ========== //
 // Parameters //
 // ========== //
+
 @description('Optional. A short identifier for the kind of deployment. Should be kept short to not run into resource-name length-constraints.')
 param serviceShort string = 'rrgmin'
 

--- a/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/deploy.bicep
+++ b/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/deploy.bicep
@@ -20,6 +20,9 @@ param roleAssignments array = []
 @description('Optional. Tags of the storage account resource.')
 param tags object = {}
 
+@description('Optional. The ID of the resource that manages this resource group.')
+param managedBy string = ''
+
 @description('Optional. Enable telemetry via a Globally Unique Identifier (GUID).')
 param enableDefaultTelemetry bool = true
 
@@ -36,10 +39,11 @@ resource defaultTelemetry 'Microsoft.Resources/deployments@2021-04-01' = if (ena
   }
 }
 
-resource resourceGroup 'Microsoft.Resources/resourceGroups@2019-05-01' = {
+resource resourceGroup 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   location: location
   name: name
   tags: tags
+  managedBy: managedBy
   properties: {}
 }
 

--- a/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/readme.md
+++ b/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/readme.md
@@ -17,7 +17,7 @@ This module deploys a resource group.
 | :-- | :-- |
 | `Microsoft.Authorization/locks` | [2020-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2020-05-01/locks) |
 | `Microsoft.Authorization/roleAssignments` | [2022-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Authorization/2022-04-01/roleAssignments) |
-| `Microsoft.Resources/resourceGroups` | [2019-05-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Resources/resourceGroups) |
+| `Microsoft.Resources/resourceGroups` | [2021-04-01](https://docs.microsoft.com/en-us/azure/templates/Microsoft.Resources/2021-04-01/resourceGroups) |
 
 ## Parameters
 
@@ -34,6 +34,7 @@ This module deploys a resource group.
 | `enableDefaultTelemetry` | bool | `True` |  | Enable telemetry via a Globally Unique Identifier (GUID). |
 | `location` | string | `[deployment().location]` |  | Location of the Resource Group. It uses the deployment's location when not provided. |
 | `lock` | string | `''` | `['', CanNotDelete, ReadOnly]` | Specify the type of lock. |
+| `managedBy` | string | `''` |  | The ID of the resource that manages this resource group. |
 | `roleAssignments` | array | `[]` |  | Array of role assignment objects that contain the 'roleDefinitionIdOrName' and 'principalId' to define RBAC role assignments on this resource. In the roleDefinitionIdOrName attribute, you can provide either the display name of the role definition, or its fully qualified ID in the following format: '/providers/Microsoft.Authorization/roleDefinitions/c2f4ef07-c644-48eb-af81-4b1b4947fb11'. |
 | `tags` | object | `{object}` |  | Tags of the storage account resource. |
 
@@ -173,7 +174,7 @@ The following module usage examples are retrieved from the content of the files 
 
 ```bicep
 module resourceGroups './Microsoft.Resources/resourceGroups/deploy.bicep' = {
-  name: '${uniqueString(deployment().name)}-test-rrgcom'
+  name: '${uniqueString(deployment().name, location)}-test-rrgcom'
   params: {
     // Required parameters
     name: '<<namePrefix>>rrgcom001'

--- a/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/version.json
+++ b/IaC/bicep/CARML/Microsoft.Resources/resourceGroups/version.json
@@ -1,4 +1,4 @@
 {
     "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/master/src/NerdBank.GitVersioning/version.schema.json",
-    "version": "0.4"
+    "version": "0.5"
 }


### PR DESCRIPTION
## PR Summary

- This update updates the ResourceGroup building block to the latest version available in CARML main today
- This version resolves a Breaking Change / Bug introduced by the Product Group with regards to property type handling

Be aware, this update can lead to issues for already deployed Resource Group instances as the name of the Role Assignment resource changes. A redeployment without manually removing such an assignment ahead of time will lead to an error message that tells the user that a Role Assignment already exists (instead of idempotently update it). This is a know ARM/Bicep issue and there is not much we can do here.

In context of this IP, your tests should work as normal, but it may be something worth pointing out in your next release notes. There is only one such deployment that you implemented that will experience this behavior: [cluster.bicep](https://github.com/Azure/aks-baseline-automation/blob/main/IaC/bicep/rg-spoke/cluster.bicep#:~:text=%7D-,module%20managedIdentityOperatorRole2%20%27../CARML/Microsoft.Resources/resourceGroups/.bicep/nested_roleAssignments.bicep%27%20%3D%20%7B,%7D,-module%20monitoringMetricsPublisherRole%20%27../CARML)

> Note: The modules will still show warnings locally as the recent Bicep changes require the implementation of the `!` operator for specific parameters. This however can be done only once the Microsoft-hosted agents are migrated from they current Bicep verion `0.13.1` to `0.14.6`.

Link to issue in CARML: https://github.com/Azure/ResourceModules/issues/2641

## PR Checklist

- [x] PR has a meaningful title
- [x] Summarized changes
- [x] This PR is ready to merge and is not **Work in Progress**
- [ ] Link to a filed issue
